### PR TITLE
TP-4: Add Firebase initialization module

### DIFF
--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,0 +1,8 @@
+import firebase from '@react-native-firebase/app';
+import auth from '@react-native-firebase/auth';
+import firestore from '@react-native-firebase/firestore';
+
+// @react-native-firebase auto-initializes from GoogleService-Info.plist (iOS)
+// and google-services.json (Android). No manual config needed.
+
+export { firebase, auth, firestore };


### PR DESCRIPTION
## What changed
- Created **lib/firebase.ts** — central module that exports Firebase app, auth, and firestore instances
- Uses @react-native-firebase auto-initialization from native config files (no manual setup needed)
- All future services and hooks will import from this module

## Files
- `lib/firebase.ts` (new)

Closes #6

## Size
Small — single file, 7 lines