### PR TITLE
TP-6: Add auth-gated root layout with route groups

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -1,0 +1,13 @@
+// app/(app)/_layout.tsx
+import { Stack } from 'expo-router';
+
+export default function AppLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: '#1a1a2e' },
+      }}
+    />
+  );
+}

--- a/app/(app)/index.tsx
+++ b/app/(app)/index.tsx
@@ -1,0 +1,27 @@
+// app/(app)/index.tsx
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { useAuth } from '../../contexts/AuthContext';
+
+export default function AppHome() {
+  const { userDoc, logout } = useAuth();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.emoji}>{userDoc?.avatarEmoji ?? '👤'}</Text>
+      <Text style={styles.title}>Welcome, {userDoc?.displayName ?? 'User'}!</Text>
+      <Text style={styles.subtitle}>My Trips screen coming in Plan 2</Text>
+      <Pressable style={styles.button} onPress={logout}>
+        <Text style={styles.buttonText}>Log Out</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#1a1a2e', padding: 24 },
+  emoji: { fontSize: 64, marginBottom: 16 },
+  title: { fontSize: 24, fontWeight: '700', color: '#ffffff', marginBottom: 8 },
+  subtitle: { fontSize: 14, color: '#a0a0b8', marginBottom: 32 },
+  button: { backgroundColor: '#6a6aff', borderRadius: 12, paddingHorizontal: 24, paddingVertical: 12 },
+  buttonText: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
+});

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,0 +1,13 @@
+// app/(auth)/_layout.tsx
+import { Stack } from 'expo-router';
+
+export default function AuthLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: '#1a1a2e' },
+      }}
+    />
+  );
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,11 @@
 // app/_layout.tsx
 import { Slot } from 'expo-router';
+import { AuthProvider } from '../contexts/AuthContext';
 
 export default function RootLayout() {
-  return <Slot />;
+  return (
+    <AuthProvider>
+      <Slot />
+    </AuthProvider>
+  );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,16 +1,31 @@
-import { View, Text, StyleSheet } from 'react-native';
+// app/index.tsx
+import { Redirect } from 'expo-router';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function Index() {
-  return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Triplan</Text>
-      <Text style={styles.subtitle}>Loading...</Text>
-    </View>
-  );
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="large" color="#6a6aff" />
+      </View>
+    );
+  }
+
+  if (!user) {
+    return <Redirect href="/(auth)/login" />;
+  }
+
+  return <Redirect href="/(app)" />;
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#1a1a2e' },
-  title: { fontSize: 32, fontWeight: '700', color: '#ffffff' },
-  subtitle: { fontSize: 16, color: '#a0a0b8', marginTop: 8 },
+  loading: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#1a1a2e',
+  },
 });


### PR DESCRIPTION
## What changed
- **Root layout** now wraps the entire app in `AuthProvider` — all screens can access auth state
- **Index screen** checks auth state on load:
  - Loading → spinner
  - Not logged in → redirects to login screen
  - Logged in → redirects to app home
- **`(auth)/` route group** — Stack navigator for login/register (headerless, dark background)
- **`(app)/` route group** — Stack navigator for authenticated screens
- **Placeholder home screen** — shows user's avatar emoji, display name, "My Trips coming in Plan 2" message, and a logout button

## How it works
```
App opens → AuthProvider checks Firebase auth state
  → Not logged in → /(auth)/login (Tasks 7-8 will add these screens)
  → Logged in → /(app)/ (shows placeholder home with logout)
```

## Files
- `app/_layout.tsx` (modified)
- `app/index.tsx` (modified)
- `app/(auth)/_layout.tsx` (new)
- `app/(app)/_layout.tsx` (new)
- `app/(app)/index.tsx` (new)

Closes #8